### PR TITLE
Add user id to registration response

### DIFF
--- a/apps/backend/app/api/v1/auth.py
+++ b/apps/backend/app/api/v1/auth.py
@@ -51,4 +51,6 @@ def register(user_data: UserRegister, session: Session = Depends(get_session)):
     session.commit()
     session.refresh(user)
     
-    return RegisterResponse(message="User created successfully", user_id=user.id)
+    return RegisterResponse(
+        message="User created successfully", email=user.email, user_id=user.id
+    )

--- a/apps/backend/app/schemas/auth.py
+++ b/apps/backend/app/schemas/auth.py
@@ -60,4 +60,5 @@ class UserResponse(SQLModel):
 class RegisterResponse(SQLModel):
     """Schema para la respuesta del registro."""
     message: str
+    user_id: int
     email: str


### PR DESCRIPTION
## Summary
- add `user_id` field to `RegisterResponse`
- include `email` and `user_id` in register endpoint response

## Testing
- `cd apps/backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b67ddfffa083248644d114523327e9

## Resumen por Sourcery

Se ha ampliado el endpoint de registro de usuario para incluir el email y el user_id en su respuesta y se ha actualizado el esquema RegisterResponse en consecuencia.

Nuevas características:
- Se añade el campo user_id al esquema RegisterResponse
- Se incluyen el email y el user_id en la respuesta del endpoint de registro

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Augment the user registration endpoint to include email and user_id in its response and update the RegisterResponse schema accordingly

New Features:
- Add user_id field to the RegisterResponse schema
- Include email and user_id in the register endpoint response

</details>