### PR TITLE
Add backend API tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Backend Tests
+
+on:
+  push:
+    paths:
+      - 'apps/backend/**'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - 'apps/backend/**'
+      - '.github/workflows/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi uvicorn[standard] sqlmodel python-multipart \
+            "python-jose[cryptography]" "passlib[bcrypt]" pydantic-settings \
+            pytest pytest-asyncio httpx
+      - name: Run tests
+        run: pytest apps/backend/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fastapi uvicorn[standard] sqlmodel python-multipart \
-            "python-jose[cryptography]" "passlib[bcrypt]" pydantic-settings \
-            pytest pytest-asyncio httpx
+          pip install -r apps/backend/requirements.txt
       - name: Run tests
         run: pytest apps/backend/tests

--- a/apps/backend/tests/test_api.py
+++ b/apps/backend/tests/test_api.py
@@ -1,0 +1,70 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+import pytest
+from sqlmodel import SQLModel, create_engine, Session
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.main import app
+from app.db.deps import get_session
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def get_session_override():
+        yield session
+
+    app.dependency_overrides[get_session] = get_session_override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_register_login_and_category_flow(client):
+    # Register a new user
+    register_data = {
+        "email": "user@example.com",
+        "password": "secret",
+        "full_name": "User Test",
+    }
+    r = client.post("/api/v1/auth/register", json=register_data)
+    assert r.status_code == 200
+    assert r.json()["email"] == register_data["email"]
+
+    # Login with the new user
+    login_data = {"email": register_data["email"], "password": register_data["password"]}
+    r = client.post("/api/v1/auth/login", json=login_data)
+    assert r.status_code == 200
+    token = r.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # List categories - should be empty initially
+    r = client.get("/api/v1/budgets/categories", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == []
+
+    # Create a new category
+    category_data = {"name": "Food", "type": "expense"}
+    r = client.post("/api/v1/budgets/categories", json=category_data, headers=headers)
+    assert r.status_code == 201
+    category_id = r.json()["id"]
+
+    # Retrieve categories again and check the new category is present
+    r = client.get("/api/v1/budgets/categories", headers=headers)
+    assert r.status_code == 200
+    categories = r.json()
+    assert any(cat["id"] == category_id and cat["name"] == "Food" for cat in categories)


### PR DESCRIPTION
## Summary
- add pytest suite covering auth and budget category endpoints
- run backend tests in GitHub Actions

## Testing
- `pytest apps/backend/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b67f5c382c83248776dc17c3dab5dc

## Resumen por Sourcery

Añade pruebas de integración para los endpoints de autenticación y categoría de presupuesto, y configura un flujo de trabajo de CI para ejecutar pruebas de backend automáticamente.

CI:
- Añade un flujo de trabajo de GitHub Actions para ejecutar pruebas de backend en cada 'push' y 'pull request'.

Pruebas:
- Introduce una suite de pytest para los endpoints de API de autenticación y categoría de presupuesto usando FastAPI TestClient.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add integration tests for auth and budget category endpoints and configure a CI workflow to run backend tests automatically

CI:
- Add GitHub Actions workflow to run backend tests on push and pull requests

Tests:
- Introduce pytest suite for authentication and budget category API endpoints using FastAPI TestClient

</details>